### PR TITLE
PF112: Questions Icon Styling

### DIFF
--- a/src/assets/divider.svg
+++ b/src/assets/divider.svg
@@ -1,0 +1,3 @@
+<svg width="1" height="44" viewBox="0 0 1 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="0.5" y1="4.22543e-10" x2="0.5" y2="44" stroke="black"/>
+</svg>

--- a/src/components/Answers/Answers.jsx
+++ b/src/components/Answers/Answers.jsx
@@ -88,7 +88,6 @@ function Answers({ questionID }) {
           </div>
         </div>
       </div>
-      {console.log(answersWithUsers.length)}
       {answersWithUsers.map(({ answer, user, profilePhoto, createdAt }) => (
         <div key={answer.id} className="answers__container">
 

--- a/src/components/Answers/Answers.scss
+++ b/src/components/Answers/Answers.scss
@@ -102,7 +102,7 @@ $font-stack-gilroy-bl: 'Gilroy-ExtraBold', serif;
   }
 
   &__content {
-    width: 90vw;
+    width: 100%;
   }
 
   &__content-text {

--- a/src/components/QuestionCard/QuestionCard.jsx
+++ b/src/components/QuestionCard/QuestionCard.jsx
@@ -6,6 +6,7 @@ import downvote from '../../assets/downvote.svg'
 import share from '../../assets/share.svg'
 import upvote from '../../assets/upvote.svg'
 import defaultUser from '../../assets/icons/defaultUser.svg'
+import divider from '../../assets/divider.svg'
 import './QuestionCard.scss'
 
 const QuestionCard = ({ createdAt, downVotes, questionContent,
@@ -47,29 +48,28 @@ const QuestionCard = ({ createdAt, downVotes, questionContent,
           <h2 className='question-card__content'>{questionContent}</h2>
         </div>
         <div className='question-card__actions'>
-          <div className='question-card__button-container'>
+          <div className='question-card__up-down-container'>
             <button className='question-card__button'>
               <img className='question-card__upvote' src={upvote} alt="test" />
+              <p className='question-card__value'>{upVotes}</p>
             </button>
-            <p className='question-card__value'>{upVotes}</p>
-          </div>
-          <div className='question-card__button-container'>
+            <img className='question-card__divider' src={divider} alt="Divider"/>
             <button className='question-card__button'>
               <img className='question-card__downvote' src={downvote} alt="test" />
+              <p className='question-card__value'>{downVotes}</p>
             </button>
-            <p className='question-card__value'>{downVotes}</p>
           </div>
           <div className='question-card__button-container'>
             <button onClick={(e)=> toggleAnswers(e)} className='question-card__button'>
               <img className='question-card__comment' src={comment} alt="test" />
+              <p className='question-card__value'>{answersCount}</p>
             </button>
-            <p className='question-card__value'>{answersCount}</p>
           </div>
           <div className='question-card__button-container'>
             <button className='question-card__button'>
               <img className='question-card__share' src={share} alt="test" />
+              <p className='question-card__value'>0</p>
             </button>
-            <p className='question-card__value'>0</p>
           </div>
         </div>
         { showAnswers && <Answers questionID={questionID}/> }

--- a/src/components/QuestionCard/QuestionCard.scss
+++ b/src/components/QuestionCard/QuestionCard.scss
@@ -3,7 +3,6 @@
 @use "../../styles/partials/_mixins" as *;
 
 .question-card {
-  // width: 60%;
   height: auto;
   margin-bottom: 1.5rem;
   border-radius: 10px;

--- a/src/components/QuestionCard/QuestionCard.scss
+++ b/src/components/QuestionCard/QuestionCard.scss
@@ -7,6 +7,7 @@
   margin-bottom: 1.5rem;
   border-radius: 10px;
   background: #FFF;
+  
   &__container {
     padding: 15px;
     }

--- a/src/components/QuestionCard/QuestionCard.scss
+++ b/src/components/QuestionCard/QuestionCard.scss
@@ -40,14 +40,38 @@
     display: flex;
   }
 
-  &__button-container {
+  &__up-down-container {
+    height: 45px;
+    width: 140px;
     display: flex;
     align-items: center;
+    justify-content: space-evenly;
+    border: #3e3e3e solid 1px;
+    border-radius: 15px;
+    margin-right: 15px;
+  }
+
+  &__divider {
+    height: 35px;
+  }
+
+  &__button-container {
+    height: 45px;
+    width: 70px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: #3e3e3e solid 1px;
+    border-radius: 15px;
+    margin-right: 15px;
   }
 
   &__button {
-    width: 42px;
-    height: 42px;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
     border: none;
     background-color: #FFF;
     padding: 0;
@@ -62,9 +86,10 @@
   &__comment,
   &__share {
     height: 30px;
+    margin-left: -10px;
   }
 
   &__value {
-    margin-right: 10px;
+    margin-right: -10px;
   }
 }


### PR DESCRIPTION
This PR does the following:
- Adjust layout in for button containers in `QuestionCard` component
- Import divider image from Figma design
- Add styling to be more in line with Mid-Fi design
- Remove console log in `Answers` component
- Adjust `content` width in `Answers.scss`
  - Text was flowing outside of container; this should fix the issue
  
  Screenshot of example `QuestionCard` after changes:
  
![Screenshot 2024-04-25 at 7 53 26 PM](https://github.com/makeitMVPadmin/P3Forum-/assets/100455148/4252d808-7816-4fa7-b1a0-f3d7ccac4436)

  